### PR TITLE
Add options parameter to wizard function

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -3,6 +3,7 @@
 on:
   push:
     paths: ["**.[rR]", "**.[qrR]md", "**.[rR]markdown", "**.[rR]nw", "**.[rR]profile"]
+  workflow_dispatch:
 
 name: Style
 

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -10,7 +10,7 @@ jobs:
   style:
     runs-on: ubuntu-latest
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ secrets.GHA_TOKEN }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,8 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Imports: 
     shiny,
-    htmltools
+    htmltools,
+    jsonlite
 Suggests: 
     testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/R/wizard.R
+++ b/R/wizard.R
@@ -9,6 +9,10 @@
 #' @param orientation wizard orientation (horizontal or vertical)
 #' @param style wizard style (dots, tabs or progress)
 #' @param show_buttons show buttons or not (TRUE or FALSE)
+#' @param id wizard id
+#' @param options A list of options. See the documentation of
+#'   'Wizard-JS' (<URL: https://github.com/AdrianVillamayor/Wizard-JS>) for
+#'   possible options.
 #' @return wizard html
 #' @export
 wizard <- function(
@@ -34,7 +38,7 @@ wizard <- function(
     
 
     # handle wizard-JS options
-    options <- modifyList(
+    options <- utils::modifyList(
         # default list
         list(
             "wz_ori" = orientation,

--- a/R/wizard.R
+++ b/R/wizard.R
@@ -16,7 +16,8 @@ wizard <- function(
     orientation = c("horizontal"),
     style = c("progress"),
     show_buttons = c(TRUE),
-    id = NULL
+    id = NULL,
+    options = list()
     ){
     
     orientation <- match.arg(orientation, c("horizontal", "vertical"))
@@ -30,13 +31,23 @@ wizard <- function(
         "TRUE" = "true",
         "FALSE" = "false"
     )
+    
+
+    # handle wizard-JS options
+    options <- modifyList(
+        # default list
+        list(
+            "wz_ori" = orientation,
+            "wz_nav_style" = style,
+            "buttons" = show_buttons
+        ),
+        options
+    )
 
     htmltools::div(
         id = id,
         class = "wizard",
-        "data-orientation" = orientation,
-        "data-style" = style,
-        "data-show-buttons" = show_buttons,
+        "data-configuration" = jsonlite::toJSON(options, auto_unbox = TRUE),
         htmltools::div(
             class = "wizard-content container",
             ...

--- a/inst/main.js
+++ b/inst/main.js
@@ -8,18 +8,8 @@ $.extend(wizard, {
   },
 
   initialize: function(el){
-    let wz_class = ".wizard";
-    let wz_ori = $(el).data("orientation");
-    let wz_nav_style = $(el).data("style"); 
-    let buttons = $(el).data("show-buttons");
     
-    let args = {
-      wz_class: wz_class,
-      wz_nav_style: wz_nav_style, // dots, tabs, progress
-      wz_ori: wz_ori, // horizontal, vertical
-      buttons: buttons,
-      navigation: "all" // buttons, nav, all
-    }
+    let args = $(el).data("configuration");
     
     const wizard = new Wizard(args);
 

--- a/man/wizard.Rd
+++ b/man/wizard.Rd
@@ -9,7 +9,8 @@ wizard(
   orientation = c("horizontal"),
   style = c("progress"),
   show_buttons = c(TRUE),
-  id = NULL
+  id = NULL,
+  options = list()
 )
 }
 \arguments{
@@ -22,6 +23,10 @@ wizard(
 \item{show_buttons}{show buttons or not (TRUE or FALSE)}
 
 \item{id}{wizard id}
+
+\item{options}{A list of options. See the documentation of
+'Wizard-JS' (<URL: https://github.com/AdrianVillamayor/Wizard-JS>) for
+possible options.}
 }
 \value{
 wizard html

--- a/tests/testthat/test-wizard.R
+++ b/tests/testthat/test-wizard.R
@@ -4,11 +4,11 @@ test_that("wizard returns the correct output", {
 
   testthat::expect_equal(htmltools::tagGetAttribute(wizard_output, "class"), "wizard")
 
-  testthat::expect_equal(htmltools::tagGetAttribute(wizard_output, "data-orientation"), "horizontal")
+  res <- htmltools::tagGetAttribute(wizard_output, "data-configuration")
 
-  testthat::expect_equal(htmltools::tagGetAttribute(wizard_output, "data-style"), "dots")
+  res <- jsonlite::parse_json(res)
 
-  testthat::expect_equal(htmltools::tagGetAttribute(wizard_output, "data-show-buttons"), "true")
+  testthat::expect_equal(res, list("wz_ori" = "horizontal", "wz_nav_style" = "dots", "buttons" = "true"))
 
   testthat::expect_equal(htmltools::tagGetAttribute(wizard_output, "id"), NULL)
   


### PR DESCRIPTION
This pull request adds an options parameter to the wizard function, allowing users to customize the behavior of the wizard. The options are passed to the underlying Wizard-JS library.