### PR TITLE
Add optional lock parameter to wizard initialization

### DIFF
--- a/R/wizard.R
+++ b/R/wizard.R
@@ -14,6 +14,7 @@
 #' @param height height in vh
 #' @param width width in vw or bootstrap size for modals (default, sm, lg, xl, fullscreen, fullscreen-sm-down, fullscreen-md-down, fullscreen-lg-down, fullscreen-xl-down, fullscreen-xxl-down)
 #' @param flex Convert the wizard to a flex container (TRUE or FALSE). flex will convert display: block to display: flex and add the htmltools::bindFillRole attribute to the wizard content.
+#' @param lock_start lock the wizard at the start (TRUE or FALSE)
 #' @param options A list of options. See the documentation of
 #'   'Wizard-JS' (<URL: https://github.com/AdrianVillamayor/Wizard-JS>) for
 #'   possible options.
@@ -29,6 +30,7 @@ wizard <- function(
     height = 60,
     width = 90,
     flex = TRUE,
+    lock_start = FALSE,
     options = list()) {
   # check inputs
   orientation <- match.arg(orientation, c("horizontal", "vertical"))
@@ -49,6 +51,11 @@ wizard <- function(
   # check if flex is logical
   if (!is.logical(flex)) {
     stop("flex must be logical")
+  }
+
+  # check if lock_start is logical
+  if (!is.logical(lock_start)) {
+    stop("lock_start must be logical")
   }
 
   # TODO fix static_backdrop
@@ -90,7 +97,8 @@ wizard <- function(
     list(
       "wz_ori" = orientation,
       "wz_nav_style" = style,
-      "buttons" = show_buttons
+      "buttons" = show_buttons,
+      "lock_start" = lock_start
     ),
     options
   )

--- a/inst/app/app-dev.R
+++ b/inst/app/app-dev.R
@@ -17,6 +17,7 @@ ui <- fluidPage(
     actionButton("show_wizard", "Show wizard"),
     wizard(
       modal = TRUE,
+      lock_start = TRUE,
       id = "my_modal",
       # start sequence of steps
       wizard_step(

--- a/inst/main.js
+++ b/inst/main.js
@@ -24,6 +24,10 @@ $.extend(wizard, {
       wizard.unlock();
     }
 
+    if (args.lock_start) {
+      wizard.lock();
+    }
+
     return wizard;
   },
 

--- a/man/wizard.Rd
+++ b/man/wizard.Rd
@@ -14,6 +14,7 @@ wizard(
   height = 60,
   width = 90,
   flex = TRUE,
+  lock_start = FALSE,
   options = list()
 )
 }
@@ -35,6 +36,8 @@ wizard(
 \item{width}{width in vw or bootstrap size for modals (default, sm, lg, xl, fullscreen, fullscreen-sm-down, fullscreen-md-down, fullscreen-lg-down, fullscreen-xl-down, fullscreen-xxl-down)}
 
 \item{flex}{Convert the wizard to a flex container (TRUE or FALSE). flex will convert display: block to display: flex and add the htmltools::bindFillRole attribute to the wizard content.}
+
+\item{lock_start}{lock the wizard at the start (TRUE or FALSE)}
 
 \item{options}{A list of options. See the documentation of
 'Wizard-JS' (<URL: https://github.com/AdrianVillamayor/Wizard-JS>) for

--- a/tests/testthat/test-wizard.R
+++ b/tests/testthat/test-wizard.R
@@ -12,7 +12,7 @@ test_that("wizard returns the correct output", {
 
   res <- jsonlite::parse_json(res)
 
-  testthat::expect_equal(res, list("wz_ori" = "horizontal", "wz_nav_style" = "dots", "buttons" = "true"))
+  testthat::expect_equal(res, list("wz_ori" = "horizontal", "wz_nav_style" = "dots", "buttons" = "true", "lock_start" = FALSE))
 
 
   # this id is necessary for modal to work


### PR DESCRIPTION
This pull request adds a new optional parameter, `lock_start`, to the `wizard` function in order to allow the wizard to be locked at the start. This parameter accepts a logical value (`TRUE` or `FALSE`). The default value is `FALSE`.