### PR TITLE
Add event listener to `submit` button in wizard and fire the id passed to wizard

### DIFF
--- a/inst/app/app-dev.R
+++ b/inst/app/app-dev.R
@@ -100,6 +100,11 @@ server <- function(input, output, session) {
   observeEvent(input$unlock_wizard, {
     wizardR::unlock("my_modal")
   })
+
+  # trigger on wizard finish
+  observeEvent(input$my_modal, {
+    print("`my_modal` wizard finished.")
+  })
 }
 
 shinyApp(ui, server)

--- a/inst/app/app-dev.R
+++ b/inst/app/app-dev.R
@@ -24,16 +24,11 @@ ui <- fluidPage(
         step_title = "Hello tag",
         # add lock button
         shiny::actionButton("lock_wizard", "Lock"),
-        shiny::actionButton("unlock_wizard", "unLock"),
-        shiny::h5("hello, this is step 0.")
+        shiny::actionButton("unlock_wizard", "unLock")
       ),
       wizard_step(
         step_title = "Numeric input",
         shiny::numericInput("number", "Select a number", value = 30, min = 20, max = 100)
-      ),
-      wizard_step(
-        step_title = "Plot output from input",
-        plotOutput("plot")
       ),
       wizard_step(
         bslib::layout_columns(

--- a/inst/utils.js
+++ b/inst/utils.js
@@ -10,10 +10,9 @@ $(document).on('click', '.wizard-btn.btn.finish', function () {
 
     modal.hide();
 
-    console.log(modal);
-
     //send message to shiny server, best is to move this to getValue
     modalId = modalId.replace("wizard-modal-", "");
+
     Shiny.setInputValue(modalId, modalId, {priority: "event"});
     
 });

--- a/inst/utils.js
+++ b/inst/utils.js
@@ -1,6 +1,6 @@
 $(document).on('click', '.wizard-btn.btn.finish', function () {
     
-    // get the modal id from the button that was clicked
+    //listen to close modal, best is to move this inputBinding
     var modalId = $(this).closest('.modal').attr('id');
     
     var modal = bootstrap.Modal.getOrCreateInstance(
@@ -9,6 +9,13 @@ $(document).on('click', '.wizard-btn.btn.finish', function () {
     );
 
     modal.hide();
+
+    console.log(modal);
+
+    //send message to shiny server, best is to move this to getValue
+    modalId = modalId.replace("wizard-modal-", "");
+    Shiny.setInputValue(modalId, modalId, {priority: "event"});
+    
 });
 
 Shiny.addCustomMessageHandler('wizard-modal', (msg) => {


### PR DESCRIPTION
This pull request adds an event listener to the `submit` button in the wizard and triggers the id passed to the wizard when it finishes.