### PR TITLE
Fix wizard finish event handling

### DIFF
--- a/R/wizard.R
+++ b/R/wizard.R
@@ -141,7 +141,7 @@ wizard <- function(
     "data-configuration" = jsonlite::toJSON(options, auto_unbox = TRUE),
     "data-active-step" = "0",
     # set data title to the title of the first step
-    "data-title" = if (length(steps) > 0) steps[[1]]$`data-title` else NULL,
+    "data-title" = first_step_title,
     content,
     wizard_dependencies()
   ) # end of wizard

--- a/R/wizard.R
+++ b/R/wizard.R
@@ -105,9 +105,13 @@ wizard <- function(
 
   steps <- list(...)
   
+  first_step_title <- "Step 0"
+  
   if (length(steps) > 0) {
     # get data-title with htmltools::htmlAttributes
+    
     first_step_title <- htmltools::tagGetAttribute(steps[[1]], "data-title")
+    
     first_step_title <- ifelse(is.null(first_step_title), "Step 0", first_step_title)
   }
 

--- a/R/wizard.R
+++ b/R/wizard.R
@@ -104,6 +104,12 @@ wizard <- function(
   )
 
   steps <- list(...)
+  
+  if (length(steps) > 0) {
+    # get data-title with htmltools::htmlAttributes
+    first_step_title <- htmltools::tagGetAttribute(steps[[1]], "data-title")
+    first_step_title <- ifelse(is.null(first_step_title), "Step 0", first_step_title)
+  }
 
   if (length(steps) > 0 && flex) {
     # iterate over steps and apply flex
@@ -134,6 +140,8 @@ wizard <- function(
     id = wiz_id,
     "data-configuration" = jsonlite::toJSON(options, auto_unbox = TRUE),
     "data-active-step" = "0",
+    # set data title to the title of the first step
+    "data-title" = if (length(steps) > 0) steps[[1]]$`data-title` else NULL,
     content,
     wizard_dependencies()
   ) # end of wizard

--- a/inst/app/app-dev.R
+++ b/inst/app/app-dev.R
@@ -98,7 +98,7 @@ server <- function(input, output, session) {
 
   # trigger on wizard finish
   observeEvent(input$my_modal, {
-    print("`my_modal` wizard finished.")
+    print(input$my_modal)
   })
 }
 

--- a/inst/main.js
+++ b/inst/main.js
@@ -36,8 +36,8 @@ $.extend(wizard, {
   },
 
   getValue: function(el) {
-    // get value from method to server if necessary
-    cur_step = $(el).attr("data-active-step");
+    cur_step = $(el).attr("data-title");
+  
     return cur_step;
   },
 
@@ -68,12 +68,23 @@ $.extend(wizard, {
         var nSteps = steps.length;
         var current = parseInt(steps.filter(".active").data("step"));
         var next = (current === nSteps) ? 0 : (current + 1);
-        
-        $(el).attr("data-active-step", next);
+
+        $(el).attr("data-active-step", parseInt(next));
 
         // Inform Shiny about visibility changes
         $(steps[current]).trigger("hidden");
         $(steps[next]).trigger("shown");
+
+
+        var title = $(steps[next]).data("title");
+
+        title = title || null;
+
+        if ( title === null) {
+          title = "Step " + $(steps[next]).data("step");
+        }
+
+        $(el).attr("data-title", title);
 
         callback(false);
       });
@@ -85,11 +96,25 @@ $.extend(wizard, {
         var steps = $(el).find(".wizard-content .wizard-step");
         var nSteps = steps.length;
         var current = steps.filter(".active").data("step");
-        var next = (current === nSteps) ? 0 : (current + 1);
-        $(el).attr("data-active-step", parseInt(current) - 1);
+        var next = (current === nSteps) ? current : (current - 1);
+        $(el).attr("data-active-step", parseInt(next));
+        
 
         $(steps[current]).trigger("hidden");
         $(steps[next]).trigger("shown");
+        
+
+        // get data-title for next step
+        var title = $(steps[next]).data("title");
+
+        // if title is undefined, set it to "Step n"
+        title = title || null;
+        if (title === null) {
+          title = "Step " + $(steps[next]).data("step");
+        }
+
+        $(el).attr("data-title", title);
+
 
         callback(false);
       });

--- a/inst/main.js
+++ b/inst/main.js
@@ -28,11 +28,20 @@ $.extend(wizard, {
       wizard.lock();
     }
 
+    this.current_step = function() {
+      return wizard.current_step();
+    }
+
     return wizard;
   },
 
   getValue: function(el) {
     // get value from method to server if necessary
+    console.log("getValue triggered")
+
+    cur_step = $(el).attr("data-active-step");
+
+    return cur_step;
   },
 
   receiveMessage: function(el, value) {

--- a/inst/main.js
+++ b/inst/main.js
@@ -38,10 +38,6 @@ $.extend(wizard, {
   getValue: function(el) {
     // get value from method to server if necessary
     cur_step = $(el).attr("data-active-step");
-
-    if (!cur_step) {
-    return "default";
-    }
     return cur_step;
   },
 

--- a/inst/main.js
+++ b/inst/main.js
@@ -37,10 +37,11 @@ $.extend(wizard, {
 
   getValue: function(el) {
     // get value from method to server if necessary
-    console.log("getValue triggered")
-
     cur_step = $(el).attr("data-active-step");
 
+    if (!cur_step) {
+    return "default";
+    }
     return cur_step;
   },
 
@@ -96,6 +97,11 @@ $.extend(wizard, {
 
         callback(false);
       });
+    });
+
+    // add event listener for wz.end
+    el.addEventListener("wz.end", function(e) {
+      callback(false);
     });
   },
 

--- a/inst/utils.js
+++ b/inst/utils.js
@@ -10,10 +10,10 @@ $(document).on('click', '.wizard-btn.btn.finish', function () {
 
     modal.hide();
 
-    //send message to shiny server, best is to move this to getValue
-    modalId = modalId.replace("wizard-modal-", "");
+    // //send message to shiny server, best is to move this to getValue
+    // modalId = modalId.replace("wizard-modal-", "");
 
-    Shiny.setInputValue(modalId, modalId, {priority: "event"});
+    // Shiny.setInputValue(modalId, modalId, {priority: "event"});
     
 });
 

--- a/inst/utils.js
+++ b/inst/utils.js
@@ -10,10 +10,10 @@ $(document).on('click', '.wizard-btn.btn.finish', function () {
 
     modal.hide();
 
-    // //send message to shiny server, best is to move this to getValue
-    // modalId = modalId.replace("wizard-modal-", "");
-
-    // Shiny.setInputValue(modalId, modalId, {priority: "event"});
+    //send message to shiny server, best is to move this to getValue
+    modalId = modalId.replace("wizard-modal-", "");
+    
+    Shiny.setInputValue(modalId, modalId, {priority: "event"});
     
 });
 

--- a/inst/utils.js
+++ b/inst/utils.js
@@ -12,8 +12,7 @@ $(document).on('click', '.wizard-btn.btn.finish', function () {
 
     //send message to shiny server, best is to move this to getValue
     modalId = modalId.replace("wizard-modal-", "");
-    
-    Shiny.setInputValue(modalId, modalId, {priority: "event"});
+    Shiny.setInputValue(modalId, "wizard_finished", {priority: "event"});
     
 });
 


### PR DESCRIPTION
This pull request fixes the event handling when the wizard finishes. Previously, the event listener was not triggered correctly, resulting in incorrect behavior (when using shiny modules). This PR adds an event listener to properly handle the wizard finish event and trigger a message to the server.