### PR TITLE
Add header and static backdrop options to wizard

### DIFF
--- a/R/wizard.R
+++ b/R/wizard.R
@@ -17,6 +17,7 @@
 #' @param lock_start lock the wizard at the start (TRUE or FALSE)
 #' @param header show header or not (TRUE or FALSE)
 #' @param header_title header title
+#' @param static_backdrop static backdrop or not (TRUE or FALSE)
 #' @param options A list of options. See the documentation of
 #'   'Wizard-JS' (<URL: https://github.com/AdrianVillamayor/Wizard-JS>) for
 #'   possible options.
@@ -35,6 +36,7 @@ wizard <- function(
     lock_start = FALSE,
     header = TRUE,
     header_title = "Wizard",
+    static_backdrop = TRUE,
     options = list()) {
   # check inputs
   orientation <- match.arg(orientation, c("horizontal", "vertical"))
@@ -62,11 +64,16 @@ wizard <- function(
     stop("lock_start must be logical")
   }
 
-  # TODO fix static_backdrop
+  
   # check if static_backdrop is logical
-  # if(!is.logical(static_backdrop)){
-  #     stop("static_backdrop must be logical")
-  # }
+  if(!is.logical(static_backdrop)){
+      stop("static_backdrop must be logical")
+  }
+
+  # check if header is logical
+  if (!is.logical(header)) {
+    stop("header must be logical")
+  }
 
   if (is.numeric(width)) {
     bs_size <- "default"
@@ -162,6 +169,8 @@ wizard <- function(
     ui <- (
       bsutils::modal(
         id = sprintf("wizard-modal-%s", id),
+        static_backdrop = TRUE,
+
         if(header){
           bsutils::modalHeader(
             title = header_title,

--- a/R/wizard.R
+++ b/R/wizard.R
@@ -169,8 +169,7 @@ wizard <- function(
     ui <- (
       bsutils::modal(
         id = sprintf("wizard-modal-%s", id),
-        static_backdrop = TRUE,
-
+        static_backdrop = static_backdrop,
         if(header){
           bsutils::modalHeader(
             title = header_title,
@@ -184,8 +183,6 @@ wizard <- function(
             htmltools::HTML(modal_width)
           )
         )
-
-        # static_backdrop = FALSE #TODO file a github issue on static_backdrop
       )
     )
   }

--- a/R/wizard.R
+++ b/R/wizard.R
@@ -15,6 +15,8 @@
 #' @param width width in vw or bootstrap size for modals (default, sm, lg, xl, fullscreen, fullscreen-sm-down, fullscreen-md-down, fullscreen-lg-down, fullscreen-xl-down, fullscreen-xxl-down)
 #' @param flex Convert the wizard to a flex container (TRUE or FALSE). flex will convert display: block to display: flex and add the htmltools::bindFillRole attribute to the wizard content.
 #' @param lock_start lock the wizard at the start (TRUE or FALSE)
+#' @param header show header or not (TRUE or FALSE)
+#' @param header_title header title
 #' @param options A list of options. See the documentation of
 #'   'Wizard-JS' (<URL: https://github.com/AdrianVillamayor/Wizard-JS>) for
 #'   possible options.
@@ -27,10 +29,12 @@ wizard <- function(
     show_buttons = TRUE,
     id = NULL,
     modal = TRUE,
-    height = 60,
+    height = 50,
     width = 90,
     flex = TRUE,
     lock_start = FALSE,
+    header = TRUE,
+    header_title = "Wizard",
     options = list()) {
   # check inputs
   orientation <- match.arg(orientation, c("horizontal", "vertical"))
@@ -158,6 +162,12 @@ wizard <- function(
     ui <- (
       bsutils::modal(
         id = sprintf("wizard-modal-%s", id),
+        if(header){
+          bsutils::modalHeader(
+            title = header_title,
+            close_button = TRUE
+          )
+        },
         bsutils::modalBody(ui),
         size = bs_size,
         htmltools::tags$head(

--- a/man/wizard.Rd
+++ b/man/wizard.Rd
@@ -17,6 +17,7 @@ wizard(
   lock_start = FALSE,
   header = TRUE,
   header_title = "Wizard",
+  static_backdrop = TRUE,
   options = list()
 )
 }
@@ -44,6 +45,8 @@ wizard(
 \item{header}{show header or not (TRUE or FALSE)}
 
 \item{header_title}{header title}
+
+\item{static_backdrop}{static backdrop or not (TRUE or FALSE)}
 
 \item{options}{A list of options. See the documentation of
 'Wizard-JS' (<URL: https://github.com/AdrianVillamayor/Wizard-JS>) for

--- a/man/wizard.Rd
+++ b/man/wizard.Rd
@@ -11,10 +11,12 @@ wizard(
   show_buttons = TRUE,
   id = NULL,
   modal = TRUE,
-  height = 60,
+  height = 50,
   width = 90,
   flex = TRUE,
   lock_start = FALSE,
+  header = TRUE,
+  header_title = "Wizard",
   options = list()
 )
 }
@@ -38,6 +40,10 @@ wizard(
 \item{flex}{Convert the wizard to a flex container (TRUE or FALSE). flex will convert display: block to display: flex and add the htmltools::bindFillRole attribute to the wizard content.}
 
 \item{lock_start}{lock the wizard at the start (TRUE or FALSE)}
+
+\item{header}{show header or not (TRUE or FALSE)}
+
+\item{header_title}{header title}
 
 \item{options}{A list of options. See the documentation of
 'Wizard-JS' (<URL: https://github.com/AdrianVillamayor/Wizard-JS>) for


### PR DESCRIPTION
This pull request adds two new options to the wizard function: header and static_backdrop. The header option allows the user to show or hide the header in the wizard, while the static_backdrop option determines whether the backdrop should be static or not. These options provide more flexibility and customization for the wizard component.